### PR TITLE
support cross compile to windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,5 +3,8 @@
 build:
 	go build -o digcaa cmd/digcaa/digcaa.go
 
+build-windows:
+	GOOS=windows GOARCH=amd64 go build -o digcaa.exe cmd/digcaa/digcaa.go
+
 clean:
 	rm -f digcaa


### PR DESCRIPTION
it's a real problem using windows to perform dig caa, whether it's using bing9 or powershell, so I found this repo, and made a little change so everyone can build windows tool.